### PR TITLE
Adjust desktop slingshot position

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -229,7 +229,8 @@ export default function Home() {
     ];
 
     // Resortera y bola (posición responsiva)
-    const slingX = 48; // Align with the center of the left buttons (24px left + 48px width / 2)
+    // En desktop lo movemos un poco a la derecha para facilitar el arrastre
+    const slingX = isMobile ? 48 : 80; // Align with buttons on mobile, give more room on desktop
     const slingY = height - 120; // Keep near bottom
     const slingStart = { x: slingX, y: slingY };
     let ball: Matter.Body | null = null;


### PR DESCRIPTION
## Summary
- shift desktop slingshot slightly right to prevent losing drag when cursor leaves page edge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d179911c48322a829bf65919bdcff