### PR TITLE
Use Are.na v3 and stabilize screensaver

### DIFF
--- a/src/app/api/arena/route.ts
+++ b/src/app/api/arena/route.ts
@@ -1,42 +1,77 @@
 export const revalidate = 3600; // cache external fetches for 1 hour
+
 import { NextResponse } from 'next/server';
+
+const ARENA_API_BASE_URL = 'https://api.are.na/v3';
+const ARENA_CHANNEL_SLUG = 'wow-wmoqvbzq_ys';
+const PER_PAGE = 50;
+const TOTAL_PAGES = 3;
+
+type ArenaImageVariant = {
+  src?: string;
+};
+
+type ArenaImage = {
+  src?: string;
+  small?: ArenaImageVariant;
+  medium?: ArenaImageVariant;
+  large?: ArenaImageVariant;
+};
+
+type ArenaBlock = {
+  image?: ArenaImage | null;
+};
+
+type ArenaContentsResponse = {
+  data?: ArenaBlock[];
+};
+
+function getArenaImageUrl(block: ArenaBlock): string | undefined {
+  return (
+    block.image?.large?.src ??
+    block.image?.medium?.src ??
+    block.image?.small?.src ??
+    block.image?.src
+  );
+}
+
+async function fetchArenaPage(page: number): Promise<ArenaContentsResponse> {
+  const response = await fetch(
+    `${ARENA_API_BASE_URL}/channels/${ARENA_CHANNEL_SLUG}/contents?per=${PER_PAGE}&page=${page}&sort=position_desc`,
+    { next: { revalidate } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Are.na v3 request failed with status ${response.status}`);
+  }
+
+  return response.json();
+}
 
 export async function GET() {
   try {
-    // Fetch multiple pages in parallel (cap pages to avoid excessive requests)
-    const perPage = 50;
-    const totalPages = 3; // fetch first 3 pages for variety
-    
-    // Fetch multiple pages in parallel
-    const pagePromises = [];
-    for (let page = 1; page <= totalPages; page++) {
-      pagePromises.push(
-        fetch(`https://api.are.na/v2/channels/wow-wmoqvbzq_ys?per=${perPage}&page=${page}`, { next: { revalidate: 3600 } })
-          .then(res => res.json())
-      );
-    }
-    
+    const pagePromises = Array.from({ length: TOTAL_PAGES }, (_, index) =>
+      fetchArenaPage(index + 1)
+    );
     const allPagesData = await Promise.all(pagePromises);
-    
-    // Extract all image URLs from all pages
-    const allImageUrls: string[] = [];
-    allPagesData.forEach(pageData => {
-      const pageImages = pageData.contents
-        ?.filter((block: { image?: unknown }) => block.image)
-        .map((block: { image?: { display?: { url: string }, original?: { url: string } } }) => {
-          return block.image?.display?.url || block.image?.original?.url;
-        })
-        .filter(Boolean) || [];
-      allImageUrls.push(...pageImages);
-    });
+
+    const uniqueImageUrls = Array.from(
+      new Set(
+        allPagesData.flatMap((pageData) =>
+          (pageData.data ?? [])
+            .map(getArenaImageUrl)
+            .filter((url): url is string => Boolean(url))
+        )
+      )
+    );
+
     // Shuffle all images using Fisher-Yates algorithm
-    const shuffledUrls = [...allImageUrls];
+    const shuffledUrls = [...uniqueImageUrls];
     for (let i = shuffledUrls.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [shuffledUrls[i], shuffledUrls[j]] = [shuffledUrls[j], shuffledUrls[i]];
     }
-    
-    
+
     return NextResponse.json({ images: shuffledUrls });
   } catch (error) {
     console.error('Error fetching Are.na images:', error);

--- a/src/app/api/arena/route.ts
+++ b/src/app/api/arena/route.ts
@@ -1,11 +1,13 @@
-export const revalidate = 3600; // cache external fetches for 1 hour
-
 import { NextResponse } from 'next/server';
 
 const ARENA_API_BASE_URL = 'https://api.are.na/v3';
+const ARENA_ACCESS_TOKEN = process.env.ARENA_ACCESS_TOKEN;
 const ARENA_CHANNEL_SLUG = 'wow-wmoqvbzq_ys';
-const PER_PAGE = 50;
-const TOTAL_PAGES = 3;
+const ARENA_CHANNEL_ID = 2752197;
+const PREMIUM_PER_PAGE = 100;
+const PREMIUM_TOTAL_PAGES = 3;
+const FALLBACK_PER_PAGE = 50;
+const FALLBACK_TOTAL_PAGES = 3;
 
 type ArenaImageVariant = {
   src?: string;
@@ -26,6 +28,15 @@ type ArenaContentsResponse = {
   data?: ArenaBlock[];
 };
 
+function shuffleUrls(urls: string[]) {
+  const shuffledUrls = [...urls];
+  for (let i = shuffledUrls.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffledUrls[i], shuffledUrls[j]] = [shuffledUrls[j], shuffledUrls[i]];
+  }
+  return shuffledUrls;
+}
+
 function getArenaImageUrl(block: ArenaBlock): string | undefined {
   return (
     block.image?.large?.src ??
@@ -37,8 +48,8 @@ function getArenaImageUrl(block: ArenaBlock): string | undefined {
 
 async function fetchArenaPage(page: number): Promise<ArenaContentsResponse> {
   const response = await fetch(
-    `${ARENA_API_BASE_URL}/channels/${ARENA_CHANNEL_SLUG}/contents?per=${PER_PAGE}&page=${page}&sort=position_desc`,
-    { next: { revalidate } }
+    `${ARENA_API_BASE_URL}/channels/${ARENA_CHANNEL_SLUG}/contents?per=${FALLBACK_PER_PAGE}&page=${page}&sort=position_desc`,
+    { cache: 'no-store' }
   );
 
   if (!response.ok) {
@@ -48,30 +59,60 @@ async function fetchArenaPage(page: number): Promise<ArenaContentsResponse> {
   return response.json();
 }
 
+async function fetchArenaRandomSearchPage(page: number, seed: number): Promise<ArenaContentsResponse> {
+  if (!ARENA_ACCESS_TOKEN) {
+    return { data: [] };
+  }
+
+  const response = await fetch(
+    `${ARENA_API_BASE_URL}/search?query=*&channel_id=${ARENA_CHANNEL_ID}&type=Block&sort=random&seed=${seed}&per=${PREMIUM_PER_PAGE}&page=${page}`,
+    {
+      cache: 'no-store',
+      headers: {
+        Authorization: `Bearer ${ARENA_ACCESS_TOKEN}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Are.na premium search failed with status ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function extractUniqueImageUrls(allPagesData: ArenaContentsResponse[]) {
+  return Array.from(
+    new Set(
+      allPagesData.flatMap((pageData) =>
+        (pageData.data ?? [])
+          .map(getArenaImageUrl)
+          .filter((url): url is string => Boolean(url))
+      )
+    )
+  );
+}
+
 export async function GET() {
   try {
-    const pagePromises = Array.from({ length: TOTAL_PAGES }, (_, index) =>
-      fetchArenaPage(index + 1)
-    );
-    const allPagesData = await Promise.all(pagePromises);
+    if (ARENA_ACCESS_TOKEN) {
+      const seed = Math.floor(Math.random() * 1_000_000_000);
+      const premiumPagePromises = Array.from({ length: PREMIUM_TOTAL_PAGES }, (_, index) =>
+        fetchArenaRandomSearchPage(index + 1, seed)
+      );
+      const premiumPagesData = await Promise.all(premiumPagePromises);
+      const premiumImageUrls = extractUniqueImageUrls(premiumPagesData);
 
-    const uniqueImageUrls = Array.from(
-      new Set(
-        allPagesData.flatMap((pageData) =>
-          (pageData.data ?? [])
-            .map(getArenaImageUrl)
-            .filter((url): url is string => Boolean(url))
-        )
-      )
-    );
-
-    // Shuffle all images using Fisher-Yates algorithm
-    const shuffledUrls = [...uniqueImageUrls];
-    for (let i = shuffledUrls.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [shuffledUrls[i], shuffledUrls[j]] = [shuffledUrls[j], shuffledUrls[i]];
+      return NextResponse.json({ images: shuffleUrls(premiumImageUrls) });
     }
 
+    const fallbackPagePromises = Array.from({ length: FALLBACK_TOTAL_PAGES }, (_, index) =>
+      fetchArenaPage(index + 1)
+    );
+    const fallbackPagesData = await Promise.all(fallbackPagePromises);
+    const fallbackImageUrls = extractUniqueImageUrls(fallbackPagesData);
+
+    const shuffledUrls = shuffleUrls(fallbackImageUrls);
     return NextResponse.json({ images: shuffledUrls });
   } catch (error) {
     console.error('Error fetching Are.na images:', error);

--- a/src/app/api/arena/route.ts
+++ b/src/app/api/arena/route.ts
@@ -11,10 +11,15 @@ const FALLBACK_TOTAL_PAGES = 3;
 
 type ArenaImageVariant = {
   src?: string;
+  url?: string;
 };
 
 type ArenaImage = {
   src?: string;
+  url?: string;
+  display?: ArenaImageVariant;
+  original?: ArenaImageVariant;
+  thumb?: ArenaImageVariant;
   small?: ArenaImageVariant;
   medium?: ArenaImageVariant;
   large?: ArenaImageVariant;
@@ -40,9 +45,19 @@ function shuffleUrls(urls: string[]) {
 function getArenaImageUrl(block: ArenaBlock): string | undefined {
   return (
     block.image?.large?.src ??
+    block.image?.large?.url ??
     block.image?.medium?.src ??
+    block.image?.medium?.url ??
     block.image?.small?.src ??
-    block.image?.src
+    block.image?.small?.url ??
+    block.image?.display?.src ??
+    block.image?.display?.url ??
+    block.image?.original?.src ??
+    block.image?.original?.url ??
+    block.image?.thumb?.src ??
+    block.image?.thumb?.url ??
+    block.image?.src ??
+    block.image?.url
   );
 }
 

--- a/src/app/components/Screensaver.tsx
+++ b/src/app/components/Screensaver.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useLayoutEffect, useState, useRef } from "react";
 import Image from "next/image";
 import { useWindowSize } from '@/hooks';
+import { getArenaImages, getCachedArenaImages } from '@/utils/arenaImages';
 
 interface ScreensaverProps {
   darkMode: boolean;
@@ -21,7 +22,7 @@ function clamp(value: number, min: number, max: number) {
 
 export default function Screensaver({ darkMode }: ScreensaverProps) {
    const [bouncingImages, setBouncingImages] = useState<BouncingImage[]>([]);
-   const [loading, setLoading] = useState(true);
+   const [loading, setLoading] = useState(() => getCachedArenaImages() === null);
    const animationRef = useRef<number>(0);
    const velocityRef = useRef({ x: 3, y: 2 });
    const positionHistory = useRef<{ x: number; y: number }[]>([]);
@@ -31,59 +32,67 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
    const windowSize = useWindowSize();
    const isMobile = windowSize.width < 768;
 
-   useEffect(() => {
-     const controller = new AbortController();
+   const initializeBouncingImages = (images: string[], viewportWidth: number, viewportHeight: number) => {
+     const mobileLayout = viewportWidth < 768;
+     const bouncing: BouncingImage[] = [];
+     const numImages = mobileLayout ? Math.min(5, images.length) : Math.min(15, images.length);
+     const imageSize = mobileLayout ? 150 : 250;
+     const maxX = Math.max(0, viewportWidth - imageSize);
+     const maxY = Math.max(0, viewportHeight - imageSize);
+     const initialX = Math.random() * maxX;
+     const initialY = Math.random() * maxY;
+     const speedMultiplier = mobileLayout ? 3 : 6;
+     const nextVelocity = {
+       x: (Math.random() - 0.5) * speedMultiplier || 1.5,
+       y: (Math.random() - 0.5) * speedMultiplier || 1,
+     };
+
+     allImages.current = images;
+     currentPosition.current = { x: initialX, y: initialY };
+     velocityRef.current = nextVelocity;
+     positionHistory.current = Array.from({ length: numImages * TRAIL_STEP }, (_, index) => ({
+       x: clamp(initialX - nextVelocity.x * index, 0, maxX),
+       y: clamp(initialY - nextVelocity.y * index, 0, maxY),
+     }));
+
+     for (let i = 0; i < numImages; i++) {
+       const imageIndex = i % images.length;
+       bouncing.push({
+         id: i,
+         imageUrl: images[imageIndex],
+         position: positionHistory.current[i * TRAIL_STEP] || { x: initialX, y: initialY }
+       });
+     }
+
+     setBouncingImages(bouncing);
+   };
+
+   useLayoutEffect(() => {
      let isActive = true;
+     const viewportWidth = window.innerWidth;
+     const viewportHeight = window.innerHeight;
+     const cachedImages = getCachedArenaImages();
+
+     if (cachedImages && cachedImages.length > 0) {
+       initializeBouncingImages(cachedImages, viewportWidth, viewportHeight);
+       setLoading(false);
+       return () => {
+         isActive = false;
+       };
+     }
+
+     setLoading(true);
 
      const initializeScreensaver = async () => {
        try {
-         const viewportWidth = window.innerWidth;
-         const viewportHeight = window.innerHeight;
-         const mobileLayout = viewportWidth < 768;
+         const images = await getArenaImages();
 
-         const response = await fetch('/api/arena', { signal: controller.signal });
-         const data = await response.json();
-
-         if (!isActive || !data.images || data.images.length === 0) {
+         if (!isActive || images.length === 0) {
            return;
          }
 
-         allImages.current = data.images;
-
-         const bouncing: BouncingImage[] = [];
-         const numImages = mobileLayout ? Math.min(5, data.images.length) : Math.min(15, data.images.length);
-         const imageSize = mobileLayout ? 150 : 250;
-         const maxX = Math.max(0, viewportWidth - imageSize);
-         const maxY = Math.max(0, viewportHeight - imageSize);
-         const initialX = Math.random() * maxX;
-         const initialY = Math.random() * maxY;
-         const speedMultiplier = mobileLayout ? 3 : 6;
-         const nextVelocity = {
-           x: (Math.random() - 0.5) * speedMultiplier || 1.5,
-           y: (Math.random() - 0.5) * speedMultiplier || 1,
-         };
-
-         currentPosition.current = { x: initialX, y: initialY };
-         velocityRef.current = nextVelocity;
-         positionHistory.current = Array.from({ length: numImages * TRAIL_STEP }, (_, index) => ({
-           x: clamp(initialX - nextVelocity.x * index, 0, maxX),
-           y: clamp(initialY - nextVelocity.y * index, 0, maxY),
-         }));
-
-         for (let i = 0; i < numImages; i++) {
-           const imageIndex = i % data.images.length;
-           bouncing.push({
-             id: i,
-             imageUrl: data.images[imageIndex],
-             position: positionHistory.current[i * TRAIL_STEP] || { x: initialX, y: initialY }
-           });
-         }
-
-         setBouncingImages(bouncing);
+         initializeBouncingImages(images, viewportWidth, viewportHeight);
        } catch (error) {
-         if (error instanceof DOMException && error.name === 'AbortError') {
-           return;
-         }
          console.error('Error:', error);
        } finally {
          if (isActive) {
@@ -96,7 +105,6 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
 
      return () => {
        isActive = false;
-       controller.abort();
      };
    }, []);
 

--- a/src/app/components/Screensaver.tsx
+++ b/src/app/components/Screensaver.tsx
@@ -214,7 +214,9 @@ export default function Screensaver({ darkMode, onClose }: ScreensaverProps) {
         backgroundColor: darkMode ? '#000' : '#fff',
         zIndex: 9999,
         cursor: onClose ? 'pointer' : 'default',
-      }}>
+      }}
+      onClick={onClose}
+      >
         <p style={{ color: darkMode ? '#ccc' : '#555', fontSize: '2rem' }}>
           Cargando...
         </p>
@@ -232,7 +234,7 @@ export default function Screensaver({ darkMode, onClose }: ScreensaverProps) {
       backgroundColor: darkMode ? '#000' : '#fff',
       zIndex: 9999,
       overflow: 'hidden',
-      cursor: 'pointer'
+      cursor: onClose ? 'pointer' : 'default'
     }}
     onClick={onClose}
     >

--- a/src/app/components/Screensaver.tsx
+++ b/src/app/components/Screensaver.tsx
@@ -6,6 +6,7 @@ import { getArenaImages, getCachedArenaImages } from '@/utils/arenaImages';
 
 interface ScreensaverProps {
   darkMode: boolean;
+  onClose?: () => void;
 }
 
 interface BouncingImage {
@@ -20,7 +21,7 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
-export default function Screensaver({ darkMode }: ScreensaverProps) {
+export default function Screensaver({ darkMode, onClose }: ScreensaverProps) {
    const [bouncingImages, setBouncingImages] = useState<BouncingImage[]>([]);
    const [loading, setLoading] = useState(() => getCachedArenaImages() === null);
    const animationRef = useRef<number>(0);
@@ -211,7 +212,8 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
         alignItems: 'center',
         justifyContent: 'center',
         backgroundColor: darkMode ? '#000' : '#fff',
-        zIndex: 9999
+        zIndex: 9999,
+        cursor: onClose ? 'pointer' : 'default',
       }}>
         <p style={{ color: darkMode ? '#ccc' : '#555', fontSize: '2rem' }}>
           Cargando...
@@ -231,7 +233,9 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
       zIndex: 9999,
       overflow: 'hidden',
       cursor: 'pointer'
-    }}>
+    }}
+    onClick={onClose}
+    >
       {/* Fixed text in center */}
       <div style={{
         position: 'absolute',

--- a/src/app/components/Screensaver.tsx
+++ b/src/app/components/Screensaver.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef } from "react";
 import Image from "next/image";
 import { useWindowSize } from '@/hooks';
 
@@ -13,11 +13,17 @@ interface BouncingImage {
   position: { x: number; y: number };
 }
 
+const TRAIL_STEP = 20;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
 export default function Screensaver({ darkMode }: ScreensaverProps) {
    const [bouncingImages, setBouncingImages] = useState<BouncingImage[]>([]);
    const [loading, setLoading] = useState(true);
-   const [velocity, setVelocity] = useState({ x: 3, y: 2 });
    const animationRef = useRef<number>(0);
+   const velocityRef = useRef({ x: 3, y: 2 });
    const positionHistory = useRef<{ x: number; y: number }[]>([]);
    const currentPosition = useRef({ x: 100, y: 100 });
    const allImages = useRef<string[]>([]);
@@ -25,63 +31,74 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
    const windowSize = useWindowSize();
    const isMobile = windowSize.width < 768;
 
-   const fetchArenaImages = useCallback(() => {
-     return fetch('/api/arena')
-       .then(res => res.json())
-       .then(data => {
-         if (data.images && data.images.length > 0) {
-           allImages.current = data.images;
-           
-           // Create multiple bouncing images
-           const bouncing: BouncingImage[] = [];
-           const numImages = isMobile ? Math.min(5, data.images.length) : Math.min(15, data.images.length); // 5 for mobile, 15 for desktop
-           const imageSize = isMobile ? 150 : 250; // Smaller size for mobile
-           
-           console.log('isMobile:', isMobile, 'numImages:', numImages, 'window width:', windowSize.width);
-           
-           // Initialize position history
-           const initialX = Math.random() * (windowSize.width - imageSize);
-           const initialY = Math.random() * (windowSize.height - imageSize);
-           currentPosition.current = { x: initialX, y: initialY };
-           
-           // Create initial positions for all images
-           for (let i = 0; i < numImages * 20; i++) {
-             positionHistory.current.push({ x: initialX, y: initialY });
-           }
-           
-           // Images are already shuffled by the API
-           for (let i = 0; i < numImages; i++) {
-             // Use images in order (already randomized), cycling through if needed
-             const imageIndex = i % data.images.length;
-             bouncing.push({
-               id: i,
-               imageUrl: data.images[imageIndex],
-               position: positionHistory.current[i * 20] || { x: initialX, y: initialY }
-             });
-           }
-           
-           setBouncingImages(bouncing);
-           
-           // Random initial velocity - slower for mobile
-           const speedMultiplier = isMobile ? 3 : 6;
-           setVelocity({
-             x: (Math.random() - 0.5) * speedMultiplier,
-             y: (Math.random() - 0.5) * speedMultiplier
+   useEffect(() => {
+     const controller = new AbortController();
+     let isActive = true;
+
+     const initializeScreensaver = async () => {
+       try {
+         const viewportWidth = window.innerWidth;
+         const viewportHeight = window.innerHeight;
+         const mobileLayout = viewportWidth < 768;
+
+         const response = await fetch('/api/arena', { signal: controller.signal });
+         const data = await response.json();
+
+         if (!isActive || !data.images || data.images.length === 0) {
+           return;
+         }
+
+         allImages.current = data.images;
+
+         const bouncing: BouncingImage[] = [];
+         const numImages = mobileLayout ? Math.min(5, data.images.length) : Math.min(15, data.images.length);
+         const imageSize = mobileLayout ? 150 : 250;
+         const maxX = Math.max(0, viewportWidth - imageSize);
+         const maxY = Math.max(0, viewportHeight - imageSize);
+         const initialX = Math.random() * maxX;
+         const initialY = Math.random() * maxY;
+         const speedMultiplier = mobileLayout ? 3 : 6;
+         const nextVelocity = {
+           x: (Math.random() - 0.5) * speedMultiplier || 1.5,
+           y: (Math.random() - 0.5) * speedMultiplier || 1,
+         };
+
+         currentPosition.current = { x: initialX, y: initialY };
+         velocityRef.current = nextVelocity;
+         positionHistory.current = Array.from({ length: numImages * TRAIL_STEP }, (_, index) => ({
+           x: clamp(initialX - nextVelocity.x * index, 0, maxX),
+           y: clamp(initialY - nextVelocity.y * index, 0, maxY),
+         }));
+
+         for (let i = 0; i < numImages; i++) {
+           const imageIndex = i % data.images.length;
+           bouncing.push({
+             id: i,
+             imageUrl: data.images[imageIndex],
+             position: positionHistory.current[i * TRAIL_STEP] || { x: initialX, y: initialY }
            });
          }
-         setLoading(false);
-         return data.images;
-       })
-       .catch(error => {
-         console.error('Error:', error);
-         setLoading(false);
-         return [];
-       });
-   }, [isMobile, windowSize.width, windowSize.height]);
 
-   useEffect(() => {
-     fetchArenaImages();
-   }, [fetchArenaImages]);
+         setBouncingImages(bouncing);
+       } catch (error) {
+         if (error instanceof DOMException && error.name === 'AbortError') {
+           return;
+         }
+         console.error('Error:', error);
+       } finally {
+         if (isActive) {
+           setLoading(false);
+         }
+       }
+     };
+
+     initializeScreensaver();
+
+     return () => {
+       isActive = false;
+       controller.abort();
+     };
+   }, []);
 
 
    useEffect(() => {
@@ -90,10 +107,11 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
      // Animation loop
      const animate = () => {
        const prev = currentPosition.current;
-       let newX = prev.x + velocity.x;
-       let newY = prev.y + velocity.y;
-       let newVelX = velocity.x;
-       let newVelY = velocity.y;
+       const currentVelocity = velocityRef.current;
+       let newX = prev.x + currentVelocity.x;
+       let newY = prev.y + currentVelocity.y;
+       let newVelX = currentVelocity.x;
+       let newVelY = currentVelocity.y;
 
          // Bounce off walls (adjusted for image size)
          const imageSize = isMobile ? 150 : 250;
@@ -136,14 +154,14 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
           });
         }
 
-      setVelocity({ x: newVelX, y: newVelY });
+      velocityRef.current = { x: newVelX, y: newVelY };
       
       // Update current position
       currentPosition.current = { x: newX, y: newY };
       
       // Update position history
       positionHistory.current.unshift({ x: newX, y: newY });
-      if (positionHistory.current.length > bouncingImages.length * 20) {
+      if (positionHistory.current.length > bouncingImages.length * TRAIL_STEP) {
         positionHistory.current.pop();
       }
       
@@ -151,7 +169,7 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
       setBouncingImages(prevImages => 
         prevImages.map((img, index) => ({
           ...img,
-          position: positionHistory.current[index * 20] || { x: newX, y: newY }
+          position: positionHistory.current[index * TRAIL_STEP] || { x: newX, y: newY }
         }))
       );
 
@@ -165,7 +183,7 @@ export default function Screensaver({ darkMode }: ScreensaverProps) {
          cancelAnimationFrame(animationRef.current);
        }
      };
-   }, [bouncingImages.length, velocity, isMobile, windowSize.width, windowSize.height]);
+   }, [bouncingImages.length, isMobile, windowSize.width, windowSize.height]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -904,19 +904,7 @@ export default function Home() {
 
       {/* Screensaver Component */}
       {showScreensaver ? (
-        <div
-          onClick={() => setShowScreensaver(false)}
-          style={{
-            position: 'fixed',
-            inset: 0,
-            backgroundColor: darkMode ? '#000' : '#fff',
-            zIndex: 9999,
-            overflow: 'hidden',
-            cursor: 'pointer',
-          }}
-        >
-          <Screensaver darkMode={darkMode} />
-        </div>
+        <Screensaver darkMode={darkMode} onClose={() => setShowScreensaver(false)} />
       ) : null}
 
       <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,14 +5,15 @@ import { GeistSans } from "geist/font/sans";
 import dynamic from 'next/dynamic';
 import { useWebHaptics } from "web-haptics/react";
 import { useWindowSize } from '@/hooks';
+import { prefetchArenaImages } from '@/utils/arenaImages';
 import ScrambleIn from './components/ScrambleIn';
 import Typewriter from './components/Typewriter';
 import AnimatedPathText from './components/TextAlongPath';
+import Screensaver from './components/Screensaver';
 
 // Lazy-load heavy optional components
 const ReactMarkdown = dynamic(() => import('react-markdown'));
 const AsciiAnimation = dynamic(() => import('./components/AsciiAnimation'), { ssr: false });
-const Screensaver = dynamic(() => import('./components/Screensaver'), { ssr: false });
 const AboutMe = dynamic(() => import('./components/AboutMe'));
 const BookDetail = dynamic(() => import('./components/BookDetail'));
 
@@ -113,6 +114,16 @@ export default function Home() {
       document.documentElement.classList.remove('dark-mode');
     }
   }, [darkMode]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      prefetchArenaImages();
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
 
   useEffect(() => {
     // Audio setup for block bounce sounds
@@ -641,6 +652,7 @@ export default function Home() {
       setSelectedSlug(null);
       setPostContent(null);
     } else {
+      prefetchArenaImages();
       setShowScreensaver(true);
     }
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -892,7 +892,17 @@ export default function Home() {
 
       {/* Screensaver Component */}
       {showScreensaver ? (
-        <div onClick={() => setShowScreensaver(false)}>
+        <div
+          onClick={() => setShowScreensaver(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: darkMode ? '#000' : '#fff',
+            zIndex: 9999,
+            overflow: 'hidden',
+            cursor: 'pointer',
+          }}
+        >
           <Screensaver darkMode={darkMode} />
         </div>
       ) : null}

--- a/src/app/test-screensaver/page.tsx
+++ b/src/app/test-screensaver/page.tsx
@@ -30,9 +30,7 @@ export default function TestScreensaver() {
       </button>
       
       {showScreensaver && (
-        <div onClick={() => setShowScreensaver(false)} style={{ cursor: "pointer" }}>
-          <Screensaver darkMode={darkMode} />
-        </div>
+        <Screensaver darkMode={darkMode} onClose={() => setShowScreensaver(false)} />
       )}
     </div>
   );

--- a/src/utils/arenaImages.ts
+++ b/src/utils/arenaImages.ts
@@ -1,0 +1,55 @@
+"use client";
+
+type ArenaImagesResponse = {
+  images?: string[];
+};
+
+const CLIENT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+let cachedImages: string[] | null = null;
+let cachedAt = 0;
+let inflightRequest: Promise<string[]> | null = null;
+
+function hasFreshCache() {
+  return cachedImages !== null && Date.now() - cachedAt < CLIENT_CACHE_TTL_MS;
+}
+
+async function fetchArenaImagesFromApi() {
+  const response = await fetch('/api/arena', { cache: 'no-store' });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch arena images: ${response.status}`);
+  }
+
+  const data: ArenaImagesResponse = await response.json();
+  const images = Array.isArray(data.images) ? data.images : [];
+
+  cachedImages = images;
+  cachedAt = Date.now();
+
+  return images;
+}
+
+export function prefetchArenaImages() {
+  void getArenaImages().catch(() => undefined);
+}
+
+export function getCachedArenaImages() {
+  return hasFreshCache() ? cachedImages : null;
+}
+
+export async function getArenaImages() {
+  if (hasFreshCache()) {
+    return cachedImages ?? [];
+  }
+
+  if (inflightRequest) {
+    return inflightRequest;
+  }
+
+  inflightRequest = fetchArenaImagesFromApi().finally(() => {
+    inflightRequest = null;
+  });
+
+  return inflightRequest;
+}


### PR DESCRIPTION
## Summary
- migrate `/api/arena` to Are.na v3 and use premium random search across the full channel when `ARENA_ACCESS_TOKEN` is configured
- stabilize screensaver initialization so the image queue starts in the correct position without the initial flash
- reduce screensaver latency by prefetching `/api/arena`, caching results on the client, and mounting `Screensaver` without a lazy chunk boundary

## Verification
- `npx tsc --noEmit`

## Notes
- preview/production must define `ARENA_ACCESS_TOKEN` to enable full-channel premium randomization; otherwise the route falls back to the public contents endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/api/arena` data source and response selection logic (including optional authenticated requests), plus rewrites screensaver initialization/caching which could affect loading behavior and image variety. Risk is moderated by clear fallback behavior and limited request fan-out.
> 
> **Overview**
> **Are.na API route updated to v3 and made token-aware.** `/api/arena` now uses the v3 endpoints, preferring an authenticated *premium* random search (seeded + paginated) when `ARENA_ACCESS_TOKEN` is set, and falling back to the public channel contents endpoint otherwise; results are de-duplicated, image URL selection is more robust across variants, and output is shuffled before returning.
> 
> **Screensaver loading/animation is stabilized and faster.** Image fetching is moved into a new client utility (`utils/arenaImages.ts`) that adds a short-lived in-memory cache and coalesces concurrent requests; `Screensaver` now initializes positions/velocity in `useLayoutEffect` (avoiding first-frame flashes), stores velocity in a ref to reduce re-renders, and supports an `onClose` prop for click-to-dismiss.
> 
> **App prefetches and mounts the screensaver more directly.** `page.tsx` prefetches Are.na images shortly after load and before showing the screensaver, and stops lazy-loading the `Screensaver` chunk boundary; test page updated to use the new `onClose` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a76850763116c8ed8c00c1811d35f0fab16e60c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->